### PR TITLE
fix mem swap mode tcl cases

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1092,7 +1092,8 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
     /* Step 4: Reply to the client. */
     if (o == NULL) {
         if (cursor == 0) {
-            if (cursorIsHot(outer_cursor)){
+            /* continue with cold data in disk swap mode */
+            if (cursorIsHot(outer_cursor) && server.swap_mode != SWAP_MODE_MEMORY) {
                 outer_cursor = 1;
                 rewindClientSwapScanCursor(c);
             } else {

--- a/src/multi.c
+++ b/src/multi.c
@@ -410,13 +410,17 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with) {
         if (!clients) continue;
         listRewind(clients,&li);
         while((ln = listNext(&li))) {
+            robj *key = dictGetKey(de);
             client *c = listNodeValue(ln);
-            c->flags |= CLIENT_DIRTY_CAS;
-            /* if (dictFind(emptied->dict, key->ptr)) {
+            if (server.swap_mode != SWAP_MODE_MEMORY) {
+                c->flags |= CLIENT_DIRTY_CAS;
+                continue;
+            }
+            if (dictFind(emptied->dict, key->ptr)) {
                 c->flags |= CLIENT_DIRTY_CAS;
             } else if (replaced_with && (dictFind(replaced_with->dict, key->ptr))) {
                 c->flags |= CLIENT_DIRTY_CAS;
-            } */
+            }
         }
     }
     dictReleaseIterator(di);

--- a/tests/integration/replication-3.tcl
+++ b/tests/integration/replication-3.tcl
@@ -196,7 +196,7 @@ start_server {tags {"repl"}} {
                     fail "Master - Replica sync fail"
                 }
                 wait_for_condition 50 100 {
-                    [r debug digest-keys] eq [r -1 debug digest-keys]
+                    [r debug digest] eq [r -1 debug digest]
                 } else {
                     fail "DEBUG DIGEST mismatch after full SYNC with many scripts"
                 }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -764,15 +764,8 @@ start_server {tags {"repl"}} {
                             set digest [$master debug digest-keys]
                             set digest0 [$replica debug digest-keys]
                         } else {
-                            $master debug swapout 
-                            $replica debug swapout
-                             wait_for_condition 100 100 {
-                                [$master info keyspace] == [$replica info keyspace]
-                            } else {    
-                                fail "Master - Replica sync fail"
-                            }
-                            set digest [$master debug digest-keys]
-                            set digest0 [$replica debug digest-keys]
+                            set digest [$master debug digest]
+                            set digest0 [$replica debug digest]
                         }
                         assert {$digest ne 0000000000000000000000000000000000000000}
                         assert {$digest eq $digest0}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -67,6 +67,7 @@ set ::disk_tests {
     swap/unit/keyspace
     swap/unit/lazydel
     swap/unit/swap_error
+    swap/unit/multi
     unit/shutdown
     unit/printver
     unit/dump


### PR DESCRIPTION
1. scan err in mem swap mode
2. flush should not touch non affected keys in mem swap mode
3. replace 'debug digest-keys' with 'debug digest' in mem swap mode