### PR TITLE
bugfix

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2573,6 +2573,9 @@ standardConfig configs[] = {
     createIntConfig("swap-threads", NULL, IMMUTABLE_CONFIG, 4, 64, server.swap_threads_num, 4, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("jemalloc-max-bg-threads", NULL, IMMUTABLE_CONFIG, 4, 16, server.jemalloc_max_bg_threads, 4, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("debug-swapout-notify-latency", NULL, MODIFIABLE_CONFIG, -1, INT_MAX, server.debug_swapout_notify_latency, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("debug-delay-before-exec-swap", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.debug_delay_before_exec_swap, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("debug-init-rocksdb-latency", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.debug_rocksdb_init_latency, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("rocksdb-stats-interval", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.rocksdb_stats_interval, 2, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/ctrip_swap.c
+++ b/src/ctrip_swap.c
@@ -482,6 +482,9 @@ int lockGlobalAndExec(clientKeyRequestFinished locked_op, uint64_t exclude_mark)
     if (exclude_mark && server.req_submitted&exclude_mark) {
         return 0;
     }
+    /* add flag before submit request otherwise when
+     * global lock no block, flag may be del just after submit */
+    server.req_submitted |= exclude_mark;
 
     client *c = server.mutex_client;
     getKeyRequestsResult result = GET_KEYREQUESTS_RESULT_INIT;
@@ -491,7 +494,6 @@ int lockGlobalAndExec(clientKeyRequestFinished locked_op, uint64_t exclude_mark)
     submitClientKeyRequests(c,&result,locked_op);
     releaseKeyRequests(&result);
     getKeyRequestsFreeResult(&result);
-    server.req_submitted |= exclude_mark;
     return 1;
 }
 

--- a/src/ctrip_swap.c
+++ b/src/ctrip_swap.c
@@ -251,7 +251,9 @@ void continueProcessCommand(client *c) {
     clientUnholdKeys(c);
     /* post command */
     commandProcessed(c);
+    protectClient(c);
     clientReleaseRequestLocks(c,NULL/*ctx unused*/);
+    unprotectClient(c);
 
     /* pipelined command might already read into querybuf, if process not
      * restarted, pending commands would not be processed again. */

--- a/src/ctrip_swap.h
+++ b/src/ctrip_swap.h
@@ -1102,6 +1102,7 @@ typedef struct swapStat {
 void initStatsSwap(void);
 void resetStatsSwap(void);
 void updateStatsSwapStart(swapRequest *req);
+void updateStatsSwapIntention(swapRequest *req);
 void updateStatsSwapRIO(swapRequest *req, RIO *rio);
 void updateStatsSwapFinish(swapRequest *req);
 

--- a/src/ctrip_swap_exec.c
+++ b/src/ctrip_swap_exec.c
@@ -1236,8 +1236,9 @@ static inline int swapRequestIsMetaType(swapRequest *req) {
 static void executeSwapRequest(swapRequest *req) {
     serverAssert(req->errcode == 0);
 
-    updateStatsSwapStart(req);
-    /* do execute swap */ 
+    updateStatsSwapIntention(req);
+    if (server.debug_delay_before_exec_swap) usleep(server.debug_delay_before_exec_swap * 1000);
+    /* do execute swap */
     switch (req->intention) {
     case SWAP_NOP:
         doNotify(req,req->errcode);
@@ -1270,6 +1271,7 @@ void processSwapRequest(swapRequest *req) {
     int errcode = 0, intention;
     uint32_t intention_flags;
 
+    updateStatsSwapStart(req);
     if (!swapRequestIsMetaType(req)) {
          executeSwapRequest(req);
          return;

--- a/src/ctrip_swap_rocks.c
+++ b/src/ctrip_swap_rocks.c
@@ -43,6 +43,7 @@ const char *swap_cf_names[CF_COUNT] = {data_cf_name, meta_cf_name, score_cf_name
 
 int rmdirRecursive(const char *path);
 int rocksInit() {
+    if (server.debug_rocksdb_init_latency) usleep(server.debug_rocksdb_init_latency * 1000);
     rocks *rocks = zcalloc(sizeof(struct rocks));
     char *errs[3] = {NULL}, dir[ROCKS_DIR_MAX_LEN];
 

--- a/src/ctrip_swap_stat.c
+++ b/src/ctrip_swap_stat.c
@@ -169,6 +169,9 @@ void updateStatsSwapStart(swapRequest *req) {
     req->swap_memory += SWAP_REQUEST_MEMORY_OVERHEAD;
     atomicIncr(server.swap_inprogress_count,1);
     atomicIncr(server.swap_inprogress_memory,req->swap_memory);
+}
+
+void updateStatsSwapIntention(swapRequest *req) {
     atomicIncr(server.swap_stats[req->intention].count,1);
     atomicIncr(server.swap_stats[req->intention].memory,req->swap_memory);
 }

--- a/src/ctrip_swap_thread.c
+++ b/src/ctrip_swap_thread.c
@@ -65,9 +65,9 @@ void *swapThreadMain (void *arg) {
 
 int swapThreadsInit() {
     int i;
-    int thread_num = server.swap_threads_num + 1;
-    server.swap_threads = zcalloc(sizeof(swapThread)*thread_num);
-    for (i = 0; i < thread_num; i++) {
+    server.total_swap_threads_num = server.swap_threads_num + 1;
+    server.swap_threads = zcalloc(sizeof(swapThread)*server.total_swap_threads_num);
+    for (i = 0; i < server.total_swap_threads_num; i++) {
         swapThread *thread = server.swap_threads+i;
         thread->id = i;
         thread->pending_reqs = listCreate();
@@ -85,8 +85,7 @@ int swapThreadsInit() {
 
 void swapThreadsDeinit() {
     int i, err;
-    int thread_num = server.swap_threads_num + 1;
-    for (i = 0; i < thread_num; i++) {
+    for (i = 0; i < server.total_swap_threads_num; i++) {
         swapThread *thread = server.swap_threads+i;
         listRelease(thread->pending_reqs);
         if (thread->thread_id == pthread_self()) continue;
@@ -124,7 +123,7 @@ void swapThreadsDispatch(swapRequest *req, int idx) {
 int swapThreadsDrained() {
     swapThread *rt;
     int drained = 1, i;
-    for (i = 0; i < server.swap_threads_num; i++) {
+    for (i = 0; i < server.total_swap_threads_num; i++) {
         rt = server.swap_threads+i;
 
         pthread_mutex_lock(&rt->lock);

--- a/src/server.c
+++ b/src/server.c
@@ -2849,6 +2849,8 @@ void initServerConfig(void) {
     server.debug_evict_keys = 0;
     server.debug_rio_latency = 0;
     server.debug_swapout_notify_latency = 0;
+    server.debug_delay_before_exec_swap = 0;
+    server.debug_rocksdb_init_latency = 0;
     server.debug_rio_error = 0;
 
     /* Failover related */

--- a/src/server.h
+++ b/src/server.h
@@ -1708,10 +1708,11 @@ struct redisServer {
     int rocksdb_disk_error;
     int rocksdb_disk_error_since;
     int rocksdb_stats_interval;
-		struct rocks *rocks;
+    struct rocks *rocks;
     struct rocksdbUtilTaskManager* util_task_manager;
     /* swap threads */
     int swap_threads_num;
+    int total_swap_threads_num; /* swap_threads_num + extra_swap_threads_num */
     struct swapThread *swap_threads;
     /* async */
     struct asyncCompleteQueue *CQ;
@@ -1741,6 +1742,8 @@ struct redisServer {
     int debug_rio_latency; /* sleep debug_rio_latency ms to simulate ssd latency. */
     int debug_swapout_notify_latency; /* sleep debug_swapout_notify_latency ms
                                         to simulate notify queue blocked after swap out */
+    int debug_delay_before_exec_swap; /* sleep debug_delay_before_exec_swap ms before exec swap request */
+    int debug_rocksdb_init_latency; /* sleep debug_rocksdb_init_latency ms before init rocksdb */
     int debug_rio_error; /* mock rio error */
     /* repl swap */
     int repl_workers;   /* num of repl worker clients */

--- a/tests/swap/unit/client.tcl
+++ b/tests/swap/unit/client.tcl
@@ -1,0 +1,21 @@
+start_server {tags "client test"} {
+    r config set debug-rio-latency 1000
+    set host [srv 0 host]
+    set port [srv 0 port]
+
+    test {kill client just finish swap} {
+        set r1 [redis $host $port]
+        set r2 [redis $host $port]
+        $r1 blocking 0
+        $r1 sadd s1 m1 m2 m3
+        $r1 evict s1
+        $r1 sismember s1 m1
+        $r2 multi
+        $r2 slaveof no one
+        $r2 client kill type normal
+        $r2 exec
+
+        set r3 [redis $host $port]
+        $r3 ping
+    }
+}

--- a/tests/swap/unit/info.tcl
+++ b/tests/swap/unit/info.tcl
@@ -1,0 +1,9 @@
+start_server {} {
+
+    test {check swap_inprogress_count after swapping not exist keys} {
+        assert_equal [getInfoProperty [{*}r info swaps] swap_inprogress_count] 0
+        r hset h1 k1 v1 k2 v2 k3 v3
+        assert_equal [getInfoProperty [{*}r info swaps] swap_inprogress_count] 0
+    }
+
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -54,6 +54,8 @@ set ::disk_tests {
     swap/unit/lazydel
     swap/unit/swap_error
     swap/unit/multi
+    swap/unit/info
+    swap/unit/client
     unit/shutdown
     ctrip/gtid_merge
     ctrip/gtid


### PR DESCRIPTION
1. process "redis-rdb-to-slaves" hang on lru cache lock
2. crash on fullsync, swap thread access server.rocks which just release in main thread
3. new master crash on sentinel failover, since client killed before client.querybuf handled finish
4. swap_inprogress_count < 0
5. bgsave hang for wrong submitted_flag